### PR TITLE
 onTabAnimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 -----------------------------------------------------------------------------------------------------------
 
-*** Updated on Monday, August 12, 2019 4:30 PM ***
+*** Updated on Monday, August 12, 2019 4:35 PM ***
 
 Branch - Animation Duration
 SVG
@@ -11,7 +11,7 @@ JS
 Branch - onTabAnimation
 JS
     -Enabled repeat for icons animations (when from and to locations are same the icon for them animates).
-	-Animated park feature icons when the tab is click (When bike tab is open, the bike icons animates).
+	-Animated park feature icons when the tab is click (When bike tab is open, the bike icons animates). Animation stop when the tab is closed
     -Some icon name (pins) were changed in the latest svg, updated the name in JS.
 
 

--- a/js/script.js
+++ b/js/script.js
@@ -504,6 +504,7 @@ window.onload = function () {
 	// closing the tab on close button click
 	CLOSE_BUTTON.onclick = function () {
 		closeInfoPanel();
+		REMOVE_CURRENT_ANIMATION();
 	};
 
 	// Functions to reset the appearance of the tabs
@@ -527,14 +528,6 @@ window.onload = function () {
 		TITLE_BAR_ICON.src = parkFeature[id].icon;
 		for (let j in GALLERY_IMAGES) GALLERY_IMAGES[j].src = parkFeature[id].galleryImages[j];
 		ABOUT_TEXT.innerHTML = parkFeature[id].about;
-
-
-		// pathToDraw = MAP_SVG.querySelector('#' + parkFeature[currentLocation][id].paths[0]);
-		// duration = parkFeature[currentLocation][id].paths[1];
-		// length = parkFeature[currentLocation][id][id].paths[2];
-		// repeat = parkFeature[currentLocation][id].paths[3];
-
-
 	}
 
 	// this function animates the infoPanel and its contents when it opens up


### PR DESCRIPTION
Branch - Animation Duration
SVG
	-updated SVG to latest
JS
	-Changed Duration to 3 sec from 7 for Bike To Bridge and Bridge to Bike Paths

Branch - onTabAnimation
JS
    -Enabled repeat for icons animations (when from and to locations are same the icon for them animates).
	-Animated park feature icons when the tab is click (When bike tab is open, the bike icons animates). Animation stop when the tab is closed
    -Some icon name (pins) were changed in the latest svg, updated the name in JS.