### PR TITLE
Update on onTabAnimation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 -----------------------------------------------------------------------------------------------------------
 
-*** Updated on Monday, August 12, 2019 4:35 PM ***
+*** Updated on Monday, August 12, 2019 7:55 PM ***
+Branch - onTabAnimation
+JS
+    -Removed REMOVE_CURRENT_ANIMATION(); from function that closes tab, so the icon animation does not stop after the tab is closed.
+
+
+-----------------------------------------------------------------------------------------------------------
+
+*** Updated on Monday, August 12, 2019 7:00 PM ***
 
 Branch - Animation Duration
 SVG

--- a/js/script.js
+++ b/js/script.js
@@ -504,7 +504,7 @@ window.onload = function () {
 	// closing the tab on close button click
 	CLOSE_BUTTON.onclick = function () {
 		closeInfoPanel();
-		REMOVE_CURRENT_ANIMATION();
+
 	};
 
 	// Functions to reset the appearance of the tabs


### PR DESCRIPTION
Branch - onTabAnimation
JS
    -Removed REMOVE_CURRENT_ANIMATION(); from function that closes tab, so the icon animation does not stop after the tab is closed.